### PR TITLE
fix: replace content-hashed record IDs with UUID v7

### DIFF
--- a/src/commands/compact.ts
+++ b/src/commands/compact.ts
@@ -657,7 +657,7 @@ export function mergeRecords(records: ExpertiseRecord[]): ExpertiseRecord {
   }
 
   // Generate ID for the merged record
-  result.id = generateRecordId(result);
+  result.id = generateRecordId();
   return result;
 }
 
@@ -890,7 +890,7 @@ async function handleApply(
     // Validate replacement
     const ajv = new Ajv();
     const validate = ajv.compile(recordSchema);
-    replacement.id = generateRecordId(replacement);
+    replacement.id = generateRecordId();
     if (!validate(replacement)) {
       const errors = (validate.errors ?? []).map(
         (err) => `${err.instancePath} ${err.message}`,

--- a/src/schemas/record-schema.ts
+++ b/src/schemas/record-schema.ts
@@ -1,6 +1,6 @@
 const linkArray = {
   type: "array",
-  items: { type: "string", pattern: "^([a-z0-9-]+:)?mx-[0-9a-f]{4,8}$" },
+  items: { type: "string", pattern: "^([a-z0-9-]+:)?mx-[0-9a-f]{4,32}$" },
 } as const;
 
 export const recordSchema = {
@@ -42,7 +42,7 @@ export const recordSchema = {
     {
       type: "object",
       properties: {
-        id: { type: "string", pattern: "^mx-[0-9a-f]{4,8}$" },
+        id: { type: "string", pattern: "^mx-[0-9a-f]{4,32}$" },
         type: { type: "string", const: "convention" },
         content: { type: "string" },
         classification: { $ref: "#/definitions/classification" },
@@ -59,7 +59,7 @@ export const recordSchema = {
     {
       type: "object",
       properties: {
-        id: { type: "string", pattern: "^mx-[0-9a-f]{4,8}$" },
+        id: { type: "string", pattern: "^mx-[0-9a-f]{4,32}$" },
         type: { type: "string", const: "pattern" },
         name: { type: "string" },
         description: { type: "string" },
@@ -84,7 +84,7 @@ export const recordSchema = {
     {
       type: "object",
       properties: {
-        id: { type: "string", pattern: "^mx-[0-9a-f]{4,8}$" },
+        id: { type: "string", pattern: "^mx-[0-9a-f]{4,32}$" },
         type: { type: "string", const: "failure" },
         description: { type: "string" },
         resolution: { type: "string" },
@@ -108,7 +108,7 @@ export const recordSchema = {
     {
       type: "object",
       properties: {
-        id: { type: "string", pattern: "^mx-[0-9a-f]{4,8}$" },
+        id: { type: "string", pattern: "^mx-[0-9a-f]{4,32}$" },
         type: { type: "string", const: "decision" },
         title: { type: "string" },
         rationale: { type: "string" },
@@ -127,7 +127,7 @@ export const recordSchema = {
     {
       type: "object",
       properties: {
-        id: { type: "string", pattern: "^mx-[0-9a-f]{4,8}$" },
+        id: { type: "string", pattern: "^mx-[0-9a-f]{4,32}$" },
         type: { type: "string", const: "reference" },
         name: { type: "string" },
         description: { type: "string" },
@@ -152,7 +152,7 @@ export const recordSchema = {
     {
       type: "object",
       properties: {
-        id: { type: "string", pattern: "^mx-[0-9a-f]{4,8}$" },
+        id: { type: "string", pattern: "^mx-[0-9a-f]{4,32}$" },
         type: { type: "string", const: "guide" },
         name: { type: "string" },
         description: { type: "string" },

--- a/src/utils/expertise.ts
+++ b/src/utils/expertise.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import {
   appendFile,
   readFile,
@@ -13,6 +13,7 @@ import type {
   RecordType,
 } from "../schemas/record.ts";
 import { DEFAULT_BM25_PARAMS, searchBM25 } from "./bm25.ts";
+import { uuidv7Hex } from "./uuid.ts";
 
 export async function readExpertiseFile(
   filePath: string,
@@ -55,29 +56,8 @@ export async function readExpertiseFile(
   return records;
 }
 
-export function generateRecordId(record: ExpertiseRecord): string {
-  let key: string;
-  switch (record.type) {
-    case "convention":
-      key = `convention:${record.content}`;
-      break;
-    case "pattern":
-      key = `pattern:${record.name}`;
-      break;
-    case "failure":
-      key = `failure:${record.description}`;
-      break;
-    case "decision":
-      key = `decision:${record.title}`;
-      break;
-    case "reference":
-      key = `reference:${record.name}`;
-      break;
-    case "guide":
-      key = `guide:${record.name}`;
-      break;
-  }
-  return `mx-${createHash("sha256").update(key).digest("hex").slice(0, 6)}`;
+export function generateRecordId(): string {
+  return `mx-${uuidv7Hex()}`;
 }
 
 export async function appendRecord(
@@ -85,7 +65,7 @@ export async function appendRecord(
   record: ExpertiseRecord,
 ): Promise<void> {
   if (!record.id) {
-    record.id = generateRecordId(record);
+    record.id = generateRecordId();
   }
   const line = `${JSON.stringify(record)}\n`;
   await appendFile(filePath, line, "utf-8");
@@ -110,7 +90,7 @@ export async function writeExpertiseFile(
 ): Promise<void> {
   for (const r of records) {
     if (!r.id) {
-      r.id = generateRecordId(r);
+      r.id = generateRecordId();
     }
   }
   const content =

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,51 @@
+/**
+ * Generate a UUID v7 as a 32-char lowercase hex string.
+ * Uses Web Crypto API (available in Bun) — zero external deps.
+ *
+ * UUID v7 layout (128 bits):
+ *   48-bit ms timestamp | 4-bit version (0x7) | 12 random bits | 2-bit variant (0b10) | 62 random bits
+ *
+ * Sub-millisecond monotonicity: when multiple IDs are generated in the same
+ * millisecond, the 12-bit rand_a field is incremented to preserve sort order.
+ */
+
+let lastTimestamp = 0;
+let seq = 0;
+
+export function uuidv7Hex(): string {
+  const now = Date.now();
+
+  if (now === lastTimestamp) {
+    seq++;
+  } else {
+    lastTimestamp = now;
+    seq = Math.floor(Math.random() * 0x100); // random start within the 12-bit space
+  }
+
+  // 16 bytes of randomness for the lower bits
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+
+  // Bytes 0-5: 48-bit timestamp (big-endian)
+  bytes[0] = (now / 2 ** 40) & 0xff;
+  bytes[1] = (now / 2 ** 32) & 0xff;
+  bytes[2] = (now / 2 ** 24) & 0xff;
+  bytes[3] = (now / 2 ** 16) & 0xff;
+  bytes[4] = (now / 2 ** 8) & 0xff;
+  bytes[5] = now & 0xff;
+
+  // Byte 6-7: version nibble 0x7 + 12-bit sequence (rand_a)
+  const seqClamped = seq & 0xfff;
+  bytes[6] = 0x70 | ((seqClamped >> 8) & 0x0f);
+  bytes[7] = seqClamped & 0xff;
+
+  // Byte 8: variant 0b10 in high 2 bits, keep low 6 random
+  bytes[8] = 0x80 | (bytes[8] & 0x3f);
+
+  // Convert to 32-char hex string
+  let hex = "";
+  for (let i = 0; i < 16; i++) {
+    hex += bytes[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -282,10 +282,10 @@ governance:
         recorded_at: new Date().toISOString(),
       };
 
-      const id = generateRecordId(record);
+      const id = generateRecordId();
       expect(id).toBeDefined();
       expect(typeof id).toBe("string");
-      expect(id).toMatch(/^mx-[a-f0-9]{6}$/);
+      expect(id).toMatch(/^mx-[0-9a-f]{32}$/);
     });
   });
 
@@ -335,8 +335,8 @@ governance:
       expect(duplicate?.index).toBe(0);
 
       // Generate IDs
-      const id1 = generateRecordId(record1);
-      const id2 = generateRecordId(record2);
+      const id1 = generateRecordId();
+      const id2 = generateRecordId();
       expect(id1).toBeDefined();
       expect(id2).toBeDefined();
       expect(id1).not.toBe(id2);

--- a/test/utils/record-id.test.ts
+++ b/test/utils/record-id.test.ts
@@ -31,87 +31,25 @@ afterEach(async () => {
 });
 
 describe("generateRecordId", () => {
-  it("generates deterministic IDs for same content", () => {
-    const record: ExpertiseRecord = {
-      type: "convention",
-      content: "Always use vitest",
-      classification: "foundational",
-      recorded_at: new Date().toISOString(),
-    };
-    const id1 = generateRecordId(record);
-    const id2 = generateRecordId(record);
-    expect(id1).toBe(id2);
+  it("generates unique IDs per call", () => {
+    const id1 = generateRecordId();
+    const id2 = generateRecordId();
+    expect(id1).not.toBe(id2);
   });
 
-  it("generates different IDs for different content", () => {
-    const r1: ExpertiseRecord = {
-      type: "convention",
-      content: "Use vitest",
-      classification: "foundational",
-      recorded_at: new Date().toISOString(),
-    };
-    const r2: ExpertiseRecord = {
-      type: "convention",
-      content: "Use jest",
-      classification: "foundational",
-      recorded_at: new Date().toISOString(),
-    };
-    expect(generateRecordId(r1)).not.toBe(generateRecordId(r2));
+  it("generates IDs matching the mx-<32-char-hex> pattern", () => {
+    const id = generateRecordId();
+    expect(id).toMatch(/^mx-[0-9a-f]{32}$/);
   });
 
-  it("generates IDs matching the mx-XXXXXX pattern", () => {
-    const record: ExpertiseRecord = {
-      type: "pattern",
-      name: "test-pattern",
-      description: "A test pattern",
-      classification: "tactical",
-      recorded_at: new Date().toISOString(),
-    };
-    const id = generateRecordId(record);
-    expect(id).toMatch(/^mx-[0-9a-f]{6}$/);
-  });
-
-  it("uses name for pattern records", () => {
-    const r1: ExpertiseRecord = {
-      type: "pattern",
-      name: "same-name",
-      description: "Different desc 1",
-      classification: "tactical",
-      recorded_at: new Date().toISOString(),
-    };
-    const r2: ExpertiseRecord = {
-      type: "pattern",
-      name: "same-name",
-      description: "Different desc 2",
-      classification: "foundational",
-      recorded_at: new Date().toISOString(),
-    };
-    // Same name = same ID (regardless of description or classification)
-    expect(generateRecordId(r1)).toBe(generateRecordId(r2));
-  });
-
-  it("uses title for decision records", () => {
-    const record: ExpertiseRecord = {
-      type: "decision",
-      title: "Use TypeScript",
-      rationale: "Type safety",
-      classification: "foundational",
-      recorded_at: new Date().toISOString(),
-    };
-    const id = generateRecordId(record);
-    expect(id).toMatch(/^mx-[0-9a-f]{6}$/);
-  });
-
-  it("uses description for failure records", () => {
-    const record: ExpertiseRecord = {
-      type: "failure",
-      description: "OOM on large files",
-      resolution: "Stream processing",
-      classification: "tactical",
-      recorded_at: new Date().toISOString(),
-    };
-    const id = generateRecordId(record);
-    expect(id).toMatch(/^mx-[0-9a-f]{6}$/);
+  it("generates IDs in timestamp order", () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      ids.push(generateRecordId());
+    }
+    for (let i = 1; i < ids.length; i++) {
+      expect(ids[i] >= ids[i - 1]).toBe(true);
+    }
   });
 });
 
@@ -129,7 +67,7 @@ describe("appendRecord with ID generation", () => {
 
     await appendRecord(filePath, record);
     const records = await readExpertiseFile(filePath);
-    expect(records[0].id).toMatch(/^mx-[0-9a-f]{6}$/);
+    expect(records[0].id).toMatch(/^mx-[0-9a-f]{32}$/);
   });
 
   it("preserves existing ID when appending", async () => {
@@ -254,7 +192,7 @@ describe("writeExpertiseFile with lazy migration", () => {
 
     await writeExpertiseFile(filePath, records);
     const read = await readExpertiseFile(filePath);
-    expect(read[0].id).toMatch(/^mx-[0-9a-f]{6}$/);
+    expect(read[0].id).toMatch(/^mx-[0-9a-f]{32}$/);
   });
 
   it("preserves existing IDs during write", async () => {

--- a/test/utils/uuid.test.ts
+++ b/test/utils/uuid.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { uuidv7Hex } from "../../src/utils/uuid.ts";
+
+describe("uuidv7Hex", () => {
+  it("returns a 32-char lowercase hex string", () => {
+    const hex = uuidv7Hex();
+    expect(hex).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("has version nibble 7 at index 12", () => {
+    const hex = uuidv7Hex();
+    expect(hex[12]).toBe("7");
+  });
+
+  it("has variant nibble 8|9|a|b at index 16", () => {
+    const hex = uuidv7Hex();
+    expect(hex[16]).toMatch(/^[89ab]$/);
+  });
+
+  it("is monotonically increasing (lexicographic order matches generation order)", () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 100; i++) {
+      ids.push(uuidv7Hex());
+    }
+    for (let i = 1; i < ids.length; i++) {
+      expect(ids[i] >= ids[i - 1]).toBe(true);
+    }
+  });
+
+  it("generates unique IDs (1000 IDs, no duplicates)", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      ids.add(uuidv7Hex());
+    }
+    expect(ids.size).toBe(1000);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace content-derived SHA256 hashing with UUID v7 for record IDs, making IDs **immutable** (editing content no longer changes the ID) and **collision-resistant** (32 hex chars vs 6)
- Add `src/utils/uuid.ts` — zero-dependency UUID v7 generator using Web Crypto API, with sub-millisecond monotonic counter
- Widen schema ID patterns from `{4,8}` to `{4,32}` so existing 6-char IDs continue to validate — **no data migration needed**

## Test plan

- [x] `bun test` — 777 tests pass (0 failures)
- [x] `bun run typecheck` — no type errors
- [x] `bun run lint` — clean
- [x] `bun src/cli.ts validate` — 85 existing JSONL records still validate
- [x] New `test/utils/uuid.test.ts` covers format, version/variant nibbles, monotonicity, uniqueness
- [x] Updated `test/utils/record-id.test.ts` covers uniqueness, pattern matching, timestamp ordering