### PR TITLE
fix(upgrade): emit valid error JSON on --check --json when registry unreachable

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { outputJson, outputJsonError } from "../utils/json-output.ts";
+import { outputJson } from "../utils/json-output.ts";
 import { printError, printSuccess, printWarning } from "../utils/palette.ts";
 import { compareSemver, getCurrentVersion, getLatestVersion } from "../utils/version.ts";
 
@@ -16,10 +16,11 @@ export function registerUpgradeCommand(program: Command): void {
 			const latest = getLatestVersion();
 			if (latest === null) {
 				if (jsonMode) {
-					outputJsonError(
-						"upgrade",
-						"Unable to reach npm registry. Check your internet connection.",
-					);
+					outputJson({
+						success: false,
+						command: "upgrade",
+						error: "Unable to reach npm registry. Check your internet connection.",
+					});
 				} else {
 					printError("Failed to check for updates: Unable to reach npm registry");
 				}
@@ -69,7 +70,11 @@ export function registerUpgradeCommand(program: Command): void {
 
 			if (result.exitCode !== 0) {
 				if (jsonMode) {
-					outputJsonError("upgrade", `bun install failed with exit code ${result.exitCode}`);
+					outputJson({
+						success: false,
+						command: "upgrade",
+						error: `bun install failed with exit code ${result.exitCode}`,
+					});
 				} else {
 					printError(`Failed to upgrade: bun install failed with exit code ${result.exitCode}`);
 				}


### PR DESCRIPTION
## Problem
`upgrade --check --json` wrote its error envelope to stderr via `outputJsonError()`, but the `--json` contract is "all structured output on stdout, exit code signals success/failure." Test `upgrade command > --check --json flag > outputs error JSON when registry is unreachable` was failing because the test reads stdout (empty) → `JSON.parse('')` → SyntaxError.

## Fix
Replaced both `outputJsonError("upgrade", ...)` calls in `src/commands/upgrade.ts` with `outputJson({ success: false, command: "upgrade", error: ... })` so the error envelope routes to stdout.

Left the global `outputJsonError` helper untouched — other commands intentionally route their error envelopes to stderr (verified by the hooks-integration test).

## Verification
- Failing test now passes.
- `pnpm check:all` — all 9 gates green (~109s).